### PR TITLE
Solved an error in editor.py and added a run.bat

### DIFF
--- a/editor.py
+++ b/editor.py
@@ -534,7 +534,7 @@ class MainGUI(QWidget):
 			elif x[0] == "scene":
 				pass
 			else:
-				print "Found unknown folder:", x[0]
+				print ("Found unknown folder:", x[0])
 
 	def SaveAs(self):
 		self.savedName = QFileDialog.getSaveFileName(self, 'Choose an environment archive', '', 'Archives (*.arc);;All Files(*)')

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,1 @@
+c:\Python27\python.exe editor.py


### PR DESCRIPTION
In editor.py, line 537, there was a print instruction without parenthesis that was leading the program to crash (better said, wan't allowing me to open it).
I solved it by adding the parenthesis. 

I've also created a run.bat that makes things easier, since opening editor.py directly doesn't work sometimes.